### PR TITLE
feat: Daily CodeSprint (deterministic daily, streak, shareable result)

### DIFF
--- a/components/TypingSession.tsx
+++ b/components/TypingSession.tsx
@@ -14,6 +14,7 @@ import { SessionControlBar } from "@/components/session/SessionControlBar";
 import { SessionTopBar } from "@/components/session/SessionTopBar";
 import { CountdownOverlay } from "@/components/session/CountdownOverlay";
 import { ResultScreen } from "@/components/session/ResultScreen";
+import { DailyChallengeCard } from "@/components/daily/DailyChallengeCard";
 
 import { usePrefersReducedMotion } from "@/lib/motion";
 import { usePreferences } from "@/lib/preferences";
@@ -30,6 +31,7 @@ import { useSessionControls } from "@/hooks/useSessionControls";
 import { useAchievements } from "@/hooks/useAchievements";
 import { useSpacedRepetition } from "@/hooks/useSpacedRepetition";
 import { useAdaptiveDifficulty } from "@/hooks/useAdaptiveDifficulty";
+import { useDaily } from "@/hooks/useDaily";
 import type { SupportedLanguage, Difficulty, SnippetLength, Snippet } from "@/lib/snippets";
 import type { DifficultyTransition } from "@/lib/adaptive";
 
@@ -48,6 +50,12 @@ export default function TypingSession() {
     const engineResetRef = useRef<() => void>(() => {});
     // Store SR recommendation function in a ref to break hook ordering dependency
     const srRecommendationRef = useRef<(availableIds: string[], currentId: string) => string | null>(() => null);
+    // Tracks whether the in-flight run is the Daily Challenge so the finish
+    // handler can record it. A ref so it survives start -> finish without re-render.
+    const isDailyRunRef = useRef(false);
+    // Set when a daily start is requested but the snippet has not propagated yet;
+    // an effect fires engine.start() once the daily snippet is active.
+    const pendingDailyStartRef = useRef(false);
 
     // Preferences
     const {
@@ -129,9 +137,15 @@ export default function TypingSession() {
     // Adaptive Difficulty
     const adaptive = useAdaptiveDifficulty(controls.language, preferences.adaptiveDifficultyEnabled);
 
+    // Daily CodeSprint (date-seeded snippet, streak, share)
+    const daily = useDaily();
+    // Whether the just-finished run was the daily; surfaces the share block on the result.
+    const [finishedDaily, setFinishedDaily] = useState(false);
+
     // Extract stable method refs to avoid callback identity churn
     const srUpdateMastery = sr.updateMastery;
     const adaptiveUpdateSkillModel = adaptive.updateSkillModel;
+    const dailyRecord = daily.record;
 
     // Session finished callback for SR + adaptive updates
     const handleSessionFinished = useCallback((sessionData: {
@@ -143,6 +157,17 @@ export default function TypingSession() {
         difficulty: Difficulty;
         lengthCategory: SnippetLength;
     }) => {
+        // Daily run: record it (idempotent per day) and flag the result screen.
+        if (isDailyRunRef.current) {
+            dailyRecord({
+                wpm: sessionData.wpm,
+                accuracy: sessionData.accuracy,
+                patternScore: sessionData.patternScore,
+            });
+            setFinishedDaily(true);
+        } else {
+            setFinishedDaily(false);
+        }
         srUpdateMastery({
             snippetId: sessionData.snippetId,
             language: sessionData.language,
@@ -158,7 +183,7 @@ export default function TypingSession() {
             accuracy: sessionData.accuracy,
             difficulty: sessionData.difficulty,
         }).then(setDifficultyTransition);
-    }, [srUpdateMastery, adaptiveUpdateSkillModel, preferences.adaptiveDifficultyEnabled]);
+    }, [srUpdateMastery, adaptiveUpdateSkillModel, preferences.adaptiveDifficultyEnabled, dailyRecord]);
 
     // Session Lifecycle (auto-advance, score saving)
     const lifecycle = useSessionLifecycle({
@@ -189,6 +214,7 @@ export default function TypingSession() {
         engineHandleKeyDown: engine.handleKeyDown,
         onReset: engine.reset,
         onNextProblem: () => {
+            isDailyRunRef.current = false;
             lifecycle.clearAutoAdvance();
             controls.handleNextProblem();
         },
@@ -227,12 +253,40 @@ export default function TypingSession() {
 
     // Handlers
     const handleStart = useCallback(() => {
+        isDailyRunRef.current = false;
         focus.enableEditorFocus();
         engine.start();
         focus.focusEditor();
     }, [focus, engine]);
 
+    // Start (or re-practice) today's Daily Challenge. setSnippet updates state
+    // asynchronously, so defer engine.start() until the daily snippet is active.
+    const handleStartDaily = useCallback(() => {
+        if (!daily.dailySnippet) return;
+        isDailyRunRef.current = true;
+        controls.setSnippet(daily.dailySnippet);
+        if (controls.snippet.id === daily.dailySnippet.id) {
+            focus.enableEditorFocus();
+            engine.start();
+            focus.focusEditor();
+        } else {
+            pendingDailyStartRef.current = true;
+        }
+    }, [daily.dailySnippet, controls, focus, engine]);
+
+    // Fire the deferred daily start once the daily snippet has become active.
+    useEffect(() => {
+        if (!pendingDailyStartRef.current) return;
+        if (!daily.dailySnippet) return;
+        if (controls.snippet.id !== daily.dailySnippet.id) return;
+        pendingDailyStartRef.current = false;
+        focus.enableEditorFocus();
+        engine.start();
+        focus.focusEditor();
+    }, [controls.snippet.id, daily.dailySnippet, focus, engine]);
+
     const handleNextProblem = useCallback(() => {
+        isDailyRunRef.current = false;
         focus.enableEditorFocus();
         lifecycle.clearAutoAdvance();
         controls.handleNextProblem();
@@ -241,6 +295,7 @@ export default function TypingSession() {
     useEffect(() => {
         if (engine.phase !== "finished") {
             setDifficultyTransition(undefined);
+            setFinishedDaily(false);
         }
     }, [engine.phase]);
 
@@ -279,6 +334,21 @@ export default function TypingSession() {
                                     dueCount={sr.dueCount}
                                     suggestedDifficulty={adaptive.suggestedDifficulty}
                                     onOpenAIDrill={() => setIsDrillPanelOpen(true)}
+                                />
+                            )}
+
+                            {/* Daily Challenge (idle only) */}
+                            {engine.phase === "idle" && (
+                                <DailyChallengeCard
+                                    dateStr={daily.today}
+                                    dayNumber={daily.dayNumber}
+                                    streak={daily.streak}
+                                    completed={daily.completed}
+                                    language={daily.dailySnippet?.language ?? controls.language}
+                                    available={daily.dailySnippet !== null}
+                                    todaysResult={daily.completed ? daily.progress.best : undefined}
+                                    onStart={handleStartDaily}
+                                    disabled={controlsDisabled}
                                 />
                             )}
 
@@ -374,6 +444,15 @@ export default function TypingSession() {
                         isAIDrill={controls.snippet.problemId.startsWith("ai-drill-")}
                         priorBestWpm={lifecycle.priorBestWpm}
                         isNewBest={lifecycle.isNewBest}
+                        daily={
+                            finishedDaily
+                                ? {
+                                      dateStr: daily.today,
+                                      dayNumber: daily.dayNumber,
+                                      streak: daily.streak,
+                                  }
+                                : undefined
+                        }
                     />
                 )}
             </AnimatePresence>

--- a/components/daily/DailyChallengeCard.tsx
+++ b/components/daily/DailyChallengeCard.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Box, Button, Flex, Text } from "@chakra-ui/react";
+
+import { DailyShareBlock } from "./DailyShareBlock";
+import type { DailyBest } from "@/lib/daily-store";
+
+export interface DailyChallengeCardProps {
+    dateStr: string;
+    dayNumber: number;
+    streak: number;
+    completed: boolean;
+    /** Snippet language label (e.g. "python"); used in the share block. */
+    language: string;
+    /** Whether a daily snippet is available (false => pool empty / still loading). */
+    available: boolean;
+    /** Today's recorded result, present once completed. */
+    todaysResult?: DailyBest;
+    /** Start (or re-practice) today's daily run. */
+    onStart: () => void;
+    disabled?: boolean;
+}
+
+/**
+ * Idle-screen entry for the Daily CodeSprint. Shows a start prompt before the
+ * daily is done, and a completed summary + streak + Wordle-style copy block after.
+ */
+export function DailyChallengeCard({
+    dateStr,
+    dayNumber,
+    streak,
+    completed,
+    language,
+    available,
+    todaysResult,
+    onStart,
+    disabled,
+}: DailyChallengeCardProps) {
+    return (
+        <Box
+            w="100%"
+            bg="var(--panel-soft)"
+            border="1px solid var(--border)"
+            borderRadius="16px"
+            boxShadow="var(--shadow)"
+            px={{ base: 5, md: 6 }}
+            py={{ base: 4, md: 5 }}
+        >
+            <Flex
+                align={{ base: "flex-start", md: "center" }}
+                justify="space-between"
+                gap={4}
+                flexDirection={{ base: "column", md: "row" }}
+            >
+                <Box>
+                    <Flex align="center" gap={2}>
+                        <Text fontSize="xl" lineHeight={1}>
+                            🗓️
+                        </Text>
+                        <Text fontSize="lg" fontWeight={700} color="var(--text)">
+                            Daily Challenge #{dayNumber}
+                        </Text>
+                    </Flex>
+                    <Text fontSize="sm" color="var(--text-subtle)" mt={1}>
+                        {completed
+                            ? "Done for today. Same snippet for everyone."
+                            : "One snippet. Same for everyone. Build your streak."}
+                    </Text>
+                </Box>
+
+                <Flex align="center" gap={4}>
+                    {streak > 0 && (
+                        <Flex align="center" gap={1.5}>
+                            <Text fontSize="lg" lineHeight={1}>
+                                🔥
+                            </Text>
+                            <Text fontSize="lg" fontWeight={700} color="var(--accent)">
+                                {streak}
+                            </Text>
+                            <Text fontSize="sm" color="var(--text-subtle)">
+                                day{streak === 1 ? "" : "s"}
+                            </Text>
+                        </Flex>
+                    )}
+
+                    <Button
+                        onClick={onStart}
+                        size="md"
+                        variant={completed ? "outline" : "solid"}
+                        bg={completed ? undefined : "var(--accent)"}
+                        color={completed ? "var(--accent)" : "var(--bg)"}
+                        borderColor="var(--accent)"
+                        _hover={
+                            completed
+                                ? { bg: "var(--accent)", color: "var(--bg)" }
+                                : { opacity: 0.9 }
+                        }
+                        px={6}
+                        disabled={disabled || !available}
+                    >
+                        {completed ? "Practice again" : "Start Daily"}
+                    </Button>
+                </Flex>
+            </Flex>
+
+            {completed && todaysResult && (
+                <Flex direction="column" align="center" gap={4} mt={5} pt={5} borderTop="1px solid var(--border)">
+                    <Flex gap={6} justify="center" flexWrap="wrap">
+                        <Stat label="best wpm" value={Math.round(todaysResult.wpm).toString()} />
+                        <Stat label="accuracy" value={`${Math.round(todaysResult.accuracy * 100)}%`} />
+                    </Flex>
+                    <DailyShareBlock
+                        dateStr={dateStr}
+                        dayNumber={dayNumber}
+                        wpm={Math.round(todaysResult.wpm)}
+                        accuracy={todaysResult.accuracy}
+                        streak={streak}
+                        language={language}
+                    />
+                </Flex>
+            )}
+        </Box>
+    );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+    return (
+        <Box textAlign="center">
+            <Text fontSize="2xl" fontWeight={700} color="var(--text)" lineHeight={1}>
+                {value}
+            </Text>
+            <Text fontSize="xs" color="var(--text-subtle)" textTransform="uppercase" letterSpacing="0.1em" mt={1}>
+                {label}
+            </Text>
+        </Box>
+    );
+}

--- a/components/daily/DailyChallengeCard.tsx
+++ b/components/daily/DailyChallengeCard.tsx
@@ -53,14 +53,9 @@ export function DailyChallengeCard({
                 flexDirection={{ base: "column", md: "row" }}
             >
                 <Box>
-                    <Flex align="center" gap={2}>
-                        <Text fontSize="xl" lineHeight={1}>
-                            🗓️
-                        </Text>
-                        <Text fontSize="lg" fontWeight={700} color="var(--text)">
-                            Daily Challenge #{dayNumber}
-                        </Text>
-                    </Flex>
+                    <Text fontSize="lg" fontWeight={700} color="var(--text)">
+                        Daily Challenge #{dayNumber}
+                    </Text>
                     <Text fontSize="sm" color="var(--text-subtle)" mt={1}>
                         {completed
                             ? "Done for today. Same snippet for everyone."

--- a/components/daily/DailyShareBlock.tsx
+++ b/components/daily/DailyShareBlock.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Box, Button, Flex, Text } from "@chakra-ui/react";
+
+import { formatDailyShare } from "@/lib/daily";
+
+export interface DailyShareBlockProps {
+    dateStr: string;
+    dayNumber: number;
+    wpm: number;
+    accuracy: number;
+    patternScore?: number;
+    streak: number;
+    language: string;
+}
+
+/**
+ * Wordle-style copy-paste daily result block with a "Copy result" button.
+ * No snippet contents are ever shown.
+ */
+export function DailyShareBlock({
+    dateStr,
+    dayNumber,
+    wpm,
+    accuracy,
+    patternScore,
+    streak,
+    language,
+}: DailyShareBlockProps) {
+    const [copied, setCopied] = useState(false);
+
+    const shareText = formatDailyShare({
+        dateStr,
+        dayNumber,
+        wpm,
+        accuracy,
+        patternScore,
+        streak,
+        language,
+    });
+
+    const handleCopy = useCallback(async () => {
+        try {
+            await navigator.clipboard.writeText(shareText);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1800);
+        } catch (err) {
+            console.warn("Failed to copy daily result", err);
+        }
+    }, [shareText]);
+
+    return (
+        <Flex direction="column" align="center" gap={3} w="100%" maxW="360px">
+            <Box
+                w="100%"
+                bg="var(--surface)"
+                border="1px solid var(--border)"
+                borderRadius="md"
+                px={4}
+                py={3}
+            >
+                <Text
+                    as="pre"
+                    fontFamily="monospace"
+                    fontSize="sm"
+                    color="var(--text)"
+                    whiteSpace="pre-wrap"
+                    textAlign="center"
+                    m={0}
+                >
+                    {shareText}
+                </Text>
+            </Box>
+            <Button
+                onClick={handleCopy}
+                size="md"
+                variant="outline"
+                borderColor="var(--accent)"
+                color="var(--accent)"
+                _hover={{ bg: "var(--accent)", color: "var(--bg)" }}
+                px={6}
+            >
+                {copied ? "Copied!" : "Copy result"}
+            </Button>
+        </Flex>
+    );
+}

--- a/components/session/ResultScreen.tsx
+++ b/components/session/ResultScreen.tsx
@@ -3,6 +3,7 @@
 import { Flex, Stack, Text } from "@chakra-ui/react";
 import { m } from "framer-motion";
 import ResultCard from "@/components/ResultCard";
+import { DailyShareBlock } from "@/components/daily/DailyShareBlock";
 import { getResultCardMotion } from "@/lib/motion-config";
 import type { SupportedLanguage, SnippetLength } from "@/lib/snippets";
 import type { ErrorEntry, HistoryEntry } from "@/hooks/useTypingEngine";
@@ -61,6 +62,12 @@ export interface ResultScreenProps {
     priorBestWpm?: number;
     /** Whether the just-finished run set a new personal best */
     isNewBest?: boolean;
+    /** Present when the finished run was the Daily Challenge; drives the share block */
+    daily?: {
+        dateStr: string;
+        dayNumber: number;
+        streak: number;
+    };
 }
 
 /**
@@ -93,6 +100,7 @@ export function ResultScreen({
     isAIDrill,
     priorBestWpm,
     isNewBest,
+    daily,
 }: ResultScreenProps) {
     const resultCardMotion = getResultCardMotion(prefersReducedMotion);
 
@@ -130,6 +138,29 @@ export function ResultScreen({
                     priorBestWpm={priorBestWpm}
                     isNewBest={isNewBest}
                 />
+
+                {daily && (
+                    <Flex direction="column" align="center" gap={3}>
+                        <Flex align="center" gap={1.5}>
+                            <Text fontSize="lg" lineHeight={1}>🔥</Text>
+                            <Text fontSize="lg" fontWeight={700} color="var(--accent)">
+                                {daily.streak}
+                            </Text>
+                            <Text fontSize="sm" color="var(--text-subtle)">
+                                day{daily.streak === 1 ? "" : "s"} streak
+                            </Text>
+                        </Flex>
+                        <DailyShareBlock
+                            dateStr={daily.dateStr}
+                            dayNumber={daily.dayNumber}
+                            wpm={Math.round(wpm)}
+                            accuracy={accuracy}
+                            patternScore={patternScore}
+                            streak={daily.streak}
+                            language={language}
+                        />
+                    </Flex>
+                )}
 
                 {(xpGained !== undefined && xpGained > 0) && (
                     <Text fontSize="md" fontWeight={600} color="var(--accent)">

--- a/hooks/useDaily.ts
+++ b/hooks/useDaily.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { getLocalDateString } from "@/lib/streaks";
+import { getDailyNumber } from "@/lib/daily";
+import { getTodaysDaily } from "@/lib/daily-pool";
+import {
+    getDailyProgress,
+    recordDailyResult,
+    type DailyProgress,
+    type DailyResult,
+} from "@/lib/daily-store";
+import type { Snippet } from "@/lib/snippets";
+
+export interface UseDailyReturn {
+    /** Today's local date as "YYYY-MM-DD". */
+    today: string;
+    /** Sequential daily number (epoch-based). */
+    dayNumber: number;
+    /** Today's date-seeded snippet from the stable pool. */
+    dailySnippet: Snippet | null;
+    /** Latest persisted daily progress (streak, completions, best). */
+    progress: DailyProgress;
+    /** Whether today's daily has already been completed. */
+    completed: boolean;
+    /** Current daily streak length. */
+    streak: number;
+    /** Record a finished daily run (idempotent per day) and refresh state. */
+    record: (result: DailyResult) => void;
+}
+
+/**
+ * Daily CodeSprint state: today's seeded snippet plus persisted streak/progress.
+ * localStorage is read after mount to avoid SSR/hydration mismatch.
+ */
+export function useDaily(): UseDailyReturn {
+    const today = useMemo(() => getLocalDateString(), []);
+    const dayNumber = useMemo(() => getDailyNumber(today), [today]);
+    const dailySnippet = useMemo(() => getTodaysDaily(today), [today]);
+
+    const [progress, setProgress] = useState<DailyProgress>(() => ({
+        streak: {
+            currentStreak: 0,
+            longestStreak: 0,
+            lastActiveDate: "",
+            streakStartDate: "",
+        },
+        lastCompletedDate: "",
+        completedDates: [],
+    }));
+
+    useEffect(() => {
+        setProgress(getDailyProgress());
+    }, [today]);
+
+    const record = useCallback(
+        (result: DailyResult) => {
+            setProgress(recordDailyResult(today, result));
+        },
+        [today]
+    );
+
+    const completed = progress.completedDates.includes(today);
+    const streak = progress.streak.currentStreak;
+
+    return {
+        today,
+        dayNumber,
+        dailySnippet,
+        progress,
+        completed,
+        streak,
+        record,
+    };
+}

--- a/lib/__tests__/daily-pool.test.ts
+++ b/lib/__tests__/daily-pool.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { getDailyPool, getTodaysDaily } from "../daily-pool";
+import { CURATED_SNIPPETS_LIST } from "../snippets";
+
+describe("getDailyPool", () => {
+    const pool = getDailyPool();
+
+    it("is non-empty", () => {
+        expect(pool.length).toBeGreaterThan(0);
+    });
+
+    it("includes the committed curated snippets", () => {
+        const poolIds = new Set(pool.map((s) => s.id));
+        for (const curated of CURATED_SNIPPETS_LIST) {
+            expect(poolIds.has(curated.id)).toBe(true);
+        }
+    });
+
+    it("includes built-in snippets from every supported language", () => {
+        const languages = new Set(pool.map((s) => s.language));
+        expect(languages.has("javascript")).toBe(true);
+        expect(languages.has("python")).toBe(true);
+        expect(languages.has("java")).toBe(true);
+        expect(languages.has("cpp")).toBe(true);
+    });
+
+    it("excludes AI drills (no problemId starts with ai-drill-)", () => {
+        expect(pool.some((s) => s.problemId.startsWith("ai-drill-"))).toBe(false);
+    });
+
+    it("is sorted by id so it is stable across users", () => {
+        const ids = pool.map((s) => s.id);
+        const sorted = [...ids].sort((a, b) => a.localeCompare(b));
+        expect(ids).toEqual(sorted);
+    });
+
+    it("has no duplicate ids", () => {
+        const ids = pool.map((s) => s.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("returns a fresh array each call (no shared mutation surface)", () => {
+        const a = getDailyPool();
+        const b = getDailyPool();
+        expect(a).not.toBe(b);
+        expect(a.map((s) => s.id)).toEqual(b.map((s) => s.id));
+    });
+});
+
+describe("getTodaysDaily", () => {
+    it("is deterministic for a given date", () => {
+        const first = getTodaysDaily("2025-06-15");
+        const second = getTodaysDaily("2025-06-15");
+        expect(first).not.toBeNull();
+        expect(first!.id).toBe(second!.id);
+    });
+
+    it("returns a snippet that exists in the daily pool", () => {
+        const pool = getDailyPool();
+        const picked = getTodaysDaily("2025-06-15");
+        expect(pool.some((s) => s.id === picked!.id)).toBe(true);
+    });
+
+    it("spreads across multiple dates", () => {
+        const dates = [
+            "2025-06-15",
+            "2025-06-16",
+            "2025-06-17",
+            "2025-06-18",
+            "2025-06-19",
+        ];
+        const ids = dates.map((d) => getTodaysDaily(d)!.id);
+        expect(new Set(ids).size).toBeGreaterThan(1);
+    });
+});

--- a/lib/__tests__/daily-store.test.ts
+++ b/lib/__tests__/daily-store.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+    getDailyProgress,
+    isDailyCompleted,
+    recordDailyResult,
+} from "../daily-store";
+
+describe("daily-store", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    describe("getDailyProgress", () => {
+        it("returns a sensible empty default when nothing is stored", () => {
+            const progress = getDailyProgress();
+            expect(progress.streak.currentStreak).toBe(0);
+            expect(progress.streak.longestStreak).toBe(0);
+            expect(progress.lastCompletedDate).toBe("");
+            expect(progress.completedDates).toEqual([]);
+            expect(progress.best).toBeUndefined();
+        });
+    });
+
+    describe("isDailyCompleted", () => {
+        it("is false before any completion", () => {
+            expect(isDailyCompleted("2025-06-01")).toBe(false);
+        });
+
+        it("is true after the date is recorded", () => {
+            recordDailyResult("2025-06-01", { wpm: 80, accuracy: 95 });
+            expect(isDailyCompleted("2025-06-01")).toBe(true);
+        });
+
+        it("is false for a date that was not recorded", () => {
+            recordDailyResult("2025-06-01", { wpm: 80, accuracy: 95 });
+            expect(isDailyCompleted("2025-06-02")).toBe(false);
+        });
+    });
+
+    describe("recordDailyResult", () => {
+        it("sets streak to 1 and records the date on first completion", () => {
+            const progress = recordDailyResult("2025-06-01", {
+                wpm: 80,
+                accuracy: 95,
+            });
+            expect(progress.streak.currentStreak).toBe(1);
+            expect(progress.lastCompletedDate).toBe("2025-06-01");
+            expect(progress.completedDates).toEqual(["2025-06-01"]);
+        });
+
+        it("increments streak to 2 on the next consecutive day", () => {
+            recordDailyResult("2025-06-01", { wpm: 80, accuracy: 95 });
+            const progress = recordDailyResult("2025-06-02", {
+                wpm: 82,
+                accuracy: 96,
+            });
+            expect(progress.streak.currentStreak).toBe(2);
+            expect(progress.lastCompletedDate).toBe("2025-06-02");
+            expect(progress.completedDates).toEqual([
+                "2025-06-01",
+                "2025-06-02",
+            ]);
+        });
+
+        it("is idempotent for the same day: streak unchanged, date not duplicated", () => {
+            recordDailyResult("2025-06-01", { wpm: 80, accuracy: 95 });
+            const progress = recordDailyResult("2025-06-01", {
+                wpm: 90,
+                accuracy: 99,
+            });
+            expect(progress.streak.currentStreak).toBe(1);
+            expect(progress.completedDates).toEqual(["2025-06-01"]);
+        });
+
+        it("resets streak to 1 after a multi-day gap", () => {
+            recordDailyResult("2025-06-01", { wpm: 80, accuracy: 95 });
+            const progress = recordDailyResult("2025-06-05", {
+                wpm: 70,
+                accuracy: 90,
+            });
+            expect(progress.streak.currentStreak).toBe(1);
+            expect(progress.completedDates).toEqual([
+                "2025-06-01",
+                "2025-06-05",
+            ]);
+        });
+
+        it("tracks best as the max wpm across days", () => {
+            recordDailyResult("2025-06-01", { wpm: 80, accuracy: 95 });
+            recordDailyResult("2025-06-02", { wpm: 110, accuracy: 98 });
+            const progress = recordDailyResult("2025-06-03", {
+                wpm: 90,
+                accuracy: 92,
+            });
+            expect(progress.best).toEqual({
+                wpm: 110,
+                accuracy: 98,
+                dateStr: "2025-06-02",
+            });
+        });
+
+        it("does not lower best when a same-day repeat has a lower wpm", () => {
+            recordDailyResult("2025-06-01", { wpm: 100, accuracy: 99 });
+            const progress = recordDailyResult("2025-06-01", {
+                wpm: 50,
+                accuracy: 80,
+            });
+            expect(progress.best?.wpm).toBe(100);
+        });
+
+        it("persists across reads via getDailyProgress", () => {
+            recordDailyResult("2025-06-01", { wpm: 80, accuracy: 95 });
+            recordDailyResult("2025-06-02", { wpm: 82, accuracy: 96 });
+            const reloaded = getDailyProgress();
+            expect(reloaded.streak.currentStreak).toBe(2);
+            expect(reloaded.completedDates).toEqual([
+                "2025-06-01",
+                "2025-06-02",
+            ]);
+        });
+    });
+});

--- a/lib/__tests__/daily.test.ts
+++ b/lib/__tests__/daily.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDailyShare, getDailyNumber, pickDailySnippet } from "../daily";
+import type { Snippet } from "../snippets";
+
+function makeSnippet(id: string, overrides: Partial<Snippet> = {}): Snippet {
+    return {
+        id,
+        problemId: `problem:${id}`,
+        title: `Title ${id}`,
+        content: `// secret content for ${id}\nconst x = 1;`,
+        language: "javascript",
+        lengthCategory: "short",
+        difficulty: "easy",
+        lines: 2,
+        ...overrides,
+    };
+}
+
+const POOL: Snippet[] = [
+    makeSnippet("c-third"),
+    makeSnippet("a-first"),
+    makeSnippet("b-second"),
+    makeSnippet("d-fourth"),
+    makeSnippet("e-fifth"),
+];
+
+describe("getDailyNumber", () => {
+    it("is 1 on the epoch date 2024-01-01", () => {
+        expect(getDailyNumber("2024-01-01")).toBe(1);
+    });
+
+    it("increments by exactly 1 per calendar day", () => {
+        const a = getDailyNumber("2024-01-01");
+        const b = getDailyNumber("2024-01-02");
+        const c = getDailyNumber("2024-01-03");
+        expect(b - a).toBe(1);
+        expect(c - b).toBe(1);
+    });
+
+    it("is stable for the same date", () => {
+        expect(getDailyNumber("2025-06-15")).toBe(getDailyNumber("2025-06-15"));
+    });
+
+    it("counts across month and year boundaries", () => {
+        const jan31 = getDailyNumber("2024-01-31");
+        const feb01 = getDailyNumber("2024-02-01");
+        expect(feb01 - jan31).toBe(1);
+
+        const dec31 = getDailyNumber("2024-12-31");
+        const jan01 = getDailyNumber("2025-01-01");
+        expect(jan01 - dec31).toBe(1);
+    });
+});
+
+describe("pickDailySnippet", () => {
+    it("returns null for an empty pool", () => {
+        expect(pickDailySnippet("2025-06-15", [])).toBeNull();
+    });
+
+    it("is deterministic: same date + same pool => identical snippet id", () => {
+        const first = pickDailySnippet("2025-06-15", POOL);
+        const second = pickDailySnippet("2025-06-15", POOL);
+        expect(first).not.toBeNull();
+        expect(first!.id).toBe(second!.id);
+    });
+
+    it("does not depend on input ordering", () => {
+        const shuffled = [...POOL].reverse();
+        const fromOrdered = pickDailySnippet("2025-06-15", POOL);
+        const fromShuffled = pickDailySnippet("2025-06-15", shuffled);
+        expect(fromOrdered!.id).toBe(fromShuffled!.id);
+    });
+
+    it("does not mutate the input array", () => {
+        const before = POOL.map((s) => s.id);
+        pickDailySnippet("2025-06-15", POOL);
+        expect(POOL.map((s) => s.id)).toEqual(before);
+    });
+
+    it("returns a snippet from the pool", () => {
+        const picked = pickDailySnippet("2025-06-15", POOL);
+        expect(POOL.some((s) => s.id === picked!.id)).toBe(true);
+    });
+
+    it("spreads across the pool: several dates are not all identical", () => {
+        const dates = [
+            "2025-06-15",
+            "2025-06-16",
+            "2025-06-17",
+            "2025-06-18",
+            "2025-06-19",
+            "2025-06-20",
+            "2025-06-21",
+            "2025-06-22",
+        ];
+        const ids = dates.map((d) => pickDailySnippet(d, POOL)!.id);
+        const distinct = new Set(ids);
+        expect(distinct.size).toBeGreaterThan(1);
+    });
+});
+
+describe("formatDailyShare", () => {
+    const baseOpts = {
+        dateStr: "2025-06-15",
+        dayNumber: 532,
+        wpm: 87,
+        accuracy: 0.964,
+        streak: 12,
+        language: "javascript",
+    };
+
+    it("includes the daily number in the title", () => {
+        const out = formatDailyShare(baseOpts);
+        expect(out).toContain("CodeSprint Daily #532");
+    });
+
+    it("includes wpm", () => {
+        const out = formatDailyShare(baseOpts);
+        expect(out).toContain("87");
+    });
+
+    it("includes accuracy as a rounded percentage", () => {
+        const out = formatDailyShare(baseOpts);
+        expect(out).toContain("96%");
+    });
+
+    it("includes the streak with a flame emoji", () => {
+        const out = formatDailyShare(baseOpts);
+        expect(out).toContain("12");
+        expect(out).toContain("🔥");
+    });
+
+    it("includes the optional pattern score when provided", () => {
+        const out = formatDailyShare({ ...baseOpts, patternScore: 73 });
+        expect(out).toContain("73");
+    });
+
+    it("does not require the pattern score", () => {
+        const out = formatDailyShare(baseOpts);
+        expect(typeof out).toBe("string");
+        expect(out.length).toBeGreaterThan(0);
+    });
+
+    it("includes the app name in a footer but no live url", () => {
+        const out = formatDailyShare(baseOpts);
+        expect(out).toContain("CodeSprint");
+        expect(out).not.toMatch(/https?:\/\//);
+    });
+
+    it("never leaks snippet content", () => {
+        const picked = pickDailySnippet(baseOpts.dateStr, POOL)!;
+        const out = formatDailyShare(baseOpts);
+        expect(out).not.toContain(picked.content);
+        expect(out).not.toContain("secret content");
+        expect(out).not.toContain("const x = 1");
+    });
+});

--- a/lib/daily-pool.ts
+++ b/lib/daily-pool.ts
@@ -1,0 +1,42 @@
+import { CURATED_SNIPPETS_LIST, type Snippet } from "./snippets";
+import { pickDailySnippet } from "./daily";
+
+import javascriptSnippets from "@/data/snippets-javascript.json";
+import pythonSnippets from "@/data/snippets-python.json";
+import javaSnippets from "@/data/snippets-java.json";
+import cppSnippets from "@/data/snippets-cpp.json";
+
+// JSON imports infer `language` as string; cast to the built-in Snippet shape.
+const BUILTIN_DATASETS = [
+    javascriptSnippets,
+    pythonSnippets,
+    javaSnippets,
+    cppSnippets,
+] as unknown as Snippet[][];
+
+/**
+ * The STABLE daily pool: curated snippets + the committed per-language corpora,
+ * EXCLUDING any user-generated AI drills, deduped, and sorted by id.
+ *
+ * Importing the committed JSON directly keeps this identical for every user, so
+ * date + pool => same snippet for everyone.
+ */
+export function getDailyPool(): Snippet[] {
+    const all: Snippet[] = [...CURATED_SNIPPETS_LIST, ...BUILTIN_DATASETS.flat()];
+
+    const seen = new Set<string>();
+    const deduped: Snippet[] = [];
+    for (const snippet of all) {
+        if (snippet.problemId.startsWith("ai-drill-")) continue;
+        if (seen.has(snippet.id)) continue;
+        seen.add(snippet.id);
+        deduped.push(snippet);
+    }
+
+    return deduped.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Today's date-seeded daily snippet, drawn from the stable built-in pool. */
+export function getTodaysDaily(dateStr: string): Snippet | null {
+    return pickDailySnippet(dateStr, getDailyPool());
+}

--- a/lib/daily-store.ts
+++ b/lib/daily-store.ts
@@ -1,0 +1,104 @@
+import { updateStreak, type StreakState } from "./streaks";
+
+export type DailyBest = {
+    wpm: number;
+    accuracy: number;
+    dateStr: string;
+};
+
+export type DailyProgress = {
+    streak: StreakState;
+    lastCompletedDate: string;
+    completedDates: string[];
+    best?: DailyBest;
+};
+
+export type DailyResult = {
+    wpm: number;
+    accuracy: number;
+    patternScore?: number;
+};
+
+const STORAGE_KEY = "codesprint-daily";
+
+function emptyProgress(): DailyProgress {
+    return {
+        streak: {
+            currentStreak: 0,
+            longestStreak: 0,
+            lastActiveDate: "",
+            streakStartDate: "",
+        },
+        lastCompletedDate: "",
+        completedDates: [],
+    };
+}
+
+export function getDailyProgress(): DailyProgress {
+    if (typeof window === "undefined") return emptyProgress();
+
+    try {
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        if (!stored) return emptyProgress();
+        const parsed = JSON.parse(stored) as Partial<DailyProgress>;
+        const fallback = emptyProgress();
+        return {
+            streak: parsed.streak ?? fallback.streak,
+            lastCompletedDate:
+                parsed.lastCompletedDate ?? fallback.lastCompletedDate,
+            completedDates: Array.isArray(parsed.completedDates)
+                ? parsed.completedDates
+                : fallback.completedDates,
+            best: parsed.best,
+        };
+    } catch (err) {
+        console.warn("Failed to load daily progress", err);
+        return emptyProgress();
+    }
+}
+
+export function isDailyCompleted(dateStr: string): boolean {
+    return getDailyProgress().completedDates.includes(dateStr);
+}
+
+export function recordDailyResult(
+    dateStr: string,
+    result: DailyResult
+): DailyProgress {
+    const prev = getDailyProgress();
+    const alreadyCompleted = prev.completedDates.includes(dateStr);
+
+    // Idempotent per day: same date never re-runs the streak or re-adds the date.
+    const streak = alreadyCompleted
+        ? prev.streak
+        : updateStreak(
+              prev.streak.lastActiveDate ? prev.streak : undefined,
+              dateStr
+          ).newState;
+
+    const completedDates = alreadyCompleted
+        ? prev.completedDates
+        : [...prev.completedDates, dateStr];
+
+    const best =
+        prev.best && prev.best.wpm >= result.wpm
+            ? prev.best
+            : { wpm: result.wpm, accuracy: result.accuracy, dateStr };
+
+    const next: DailyProgress = {
+        streak,
+        lastCompletedDate: dateStr,
+        completedDates,
+        best,
+    };
+
+    if (typeof window !== "undefined") {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        } catch (err) {
+            console.warn("Failed to save daily progress", err);
+        }
+    }
+
+    return next;
+}

--- a/lib/daily.ts
+++ b/lib/daily.ts
@@ -1,0 +1,61 @@
+import type { Snippet } from "./snippets";
+
+const EPOCH = "2024-01-01";
+const MS_PER_DAY = 86_400_000;
+
+function parseDateString(dateStr: string): Date {
+    const [year, month, day] = dateStr.split("-").map(Number);
+    return new Date(year, month - 1, day);
+}
+
+function daysBetween(dateStrA: string, dateStrB: string): number {
+    const a = parseDateString(dateStrA);
+    const b = parseDateString(dateStrB);
+    return Math.round((b.getTime() - a.getTime()) / MS_PER_DAY);
+}
+
+// Integer day index since the fixed epoch, 1-based so the epoch is "Daily #1".
+export function getDailyNumber(dateStr: string): number {
+    return daysBetween(EPOCH, dateStr) + 1;
+}
+
+// Stable 32-bit djb2 string hash; deterministic across machines and runs.
+function hashString(value: string): number {
+    let hash = 5381;
+    for (let i = 0; i < value.length; i++) {
+        hash = (hash * 33) ^ value.charCodeAt(i);
+    }
+    return hash >>> 0;
+}
+
+// Deterministic: same date + same pool => same snippet for everyone.
+export function pickDailySnippet(dateStr: string, snippets: Snippet[]): Snippet | null {
+    if (snippets.length === 0) return null;
+    const sorted = [...snippets].sort((a, b) => a.id.localeCompare(b.id));
+    const index = hashString(dateStr) % sorted.length;
+    return sorted[index];
+}
+
+type DailyShareOptions = {
+    dateStr: string;
+    dayNumber: number;
+    wpm: number;
+    accuracy: number;
+    patternScore?: number;
+    streak: number;
+    language: string;
+};
+
+// Compact Wordle-style copy-paste block. No snippet contents or spoilers.
+export function formatDailyShare(opts: DailyShareOptions): string {
+    const accuracyPercent = Math.round(opts.accuracy * 100);
+    const lines = [
+        `CodeSprint Daily #${opts.dayNumber}`,
+        `⚡ ${opts.wpm} wpm · 🎯 ${accuracyPercent}%${
+            opts.patternScore !== undefined ? ` · 🧩 ${opts.patternScore}` : ""
+        }`,
+        `🔥 ${opts.streak} day streak`,
+        `CodeSprint`,
+    ];
+    return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

The **Daily CodeSprint** feature, the growth hook from the office-hours strategy, plus a design polish. A deterministic snippet-of-the-day (same for everyone), a daily streak, and a Wordle-style shareable result. Built TDD, 632 tests green, lint + types clean, and design-reviewed at desktop and mobile.

## Commits

- **`feat:`** Daily CodeSprint (date-seeded daily, streak, shareable result)
- **`style(design):`** drop decorative calendar emoji from the Daily card title (design-review polish)

## What it does

- **Deterministic snippet-of-the-day** (`lib/daily.ts`): `getDailyNumber` (today = Daily #883), `pickDailySnippet` (djb2 hash over an id-sorted pool → same pick for everyone), `formatDailyShare` (Wordle-style block).
- **Determinism guard** (`lib/daily-pool.ts`): picks from the stable built-in pool (`CURATED` + committed per-language JSON), excludes the user's AI drills, so the daily is identical across users.
- **Daily streak + persistence** (`lib/daily-store.ts`): reuses `updateStreak` from `lib/streaks.ts`, idempotent per day, tracks best.
- **UI**: a "Daily Challenge #N" entry on the idle screen with a completed state, a Copy-result button, and the share block surfaced on the result screen. Wired into `TypingSession` (`isDaily` flow) and `ResultScreen`.

## Test plan

- [x] `bun run test` — 632 pass (43 files); determinism verified (`getDailyNumber('2026-06-01')` = 883, same pick across 50 calls)
- [x] `bun run lint` — clean
- [x] `npx tsc --noEmit` — no new errors in touched files
- [x] Design review (desktop + mobile) — report in `~/.gstack/projects/.../design-audit-20260601/`
- [ ] **Deploy to a real URL** so the share result + footer resolve (next step; required before any community launch)

## Notes

- The completed-state card shows all-time **best** wpm/accuracy (labeled), not today's exact run after a reload. A per-date result map is a small follow-up.
- The Daily is buildable/works fully client-side; hosted short IDs / OG previews for shared results come with the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily Challenge feature: Start daily typing challenges with tracked completion status
  * Streak tracking: View current streak with flame emoji indicator
  * Daily results sharing: Copy and share daily performance (WPM, accuracy, streak) via formatted share text
  * Results summary: Display daily stats including best WPM, accuracy, and streak after completing a daily challenge

<!-- end of auto-generated comment: release notes by coderabbit.ai -->